### PR TITLE
fix: prompt player to try again on death

### DIFF
--- a/.squad/agents/judy/history.md
+++ b/.squad/agents/judy/history.md
@@ -65,3 +65,17 @@
 - **Decisions merged**: Inbox decision on WorldBuilder removal merged into decisions.md with full rationale and impact analysis
 - **Judy's history updated**: Added Session 7 entry noting WorldBuilder removal, test count now 168
 
+### Session 8 — Try-Again on Death (Issue #29)
+
+- **`Func<GameState>?` factory pattern**: Added optional `stateFactory` parameter to `GameEngine` constructor. When provided and player dies, a fresh `GameState` is created by invoking the factory — no shared state carries over.
+- **`Run()` wraps `RunSession()`**: Extracted the entire single-session game loop into `private RunSession()`. `Run()` owns the retry loop; `RunSession()` owns one game from banner to end message.
+- **Restart shows full intro**: Because `RunSession()` includes the banner and initial look, the player gets a clean fresh start — exactly the same experience as a first launch.
+- **"Try again?" prompt only on death**: Win and voluntary quit exit cleanly without prompting. Only `HasLost == true` with a non-null factory triggers the prompt.
+- **`ColorConsole.Yellow()`** used for the prompt, consistent with the cyberpunk theme palette.
+- **Backward compatibility preserved**: All existing tests construct `GameEngine` without a factory (`stateFactory = null` default). 199 tests pass unchanged.
+- **`_state` is no longer `readonly`**: Required so the retry loop can replace it with a fresh instance from the factory.
+
+## Team Updates
+
+- **2026-03-10 — River validated restart feature:** 6 new TryAgainTests.cs tests cover all restart branches and backward compat. Banner line count detects session restart cleanly. All 205 tests passing.
+

--- a/.squad/agents/river/history.md
+++ b/.squad/agents/river/history.md
@@ -101,6 +101,34 @@
 
 **Pattern observed:** The empty-requirements variant as "default atmospheric" is now an established content pattern. Any room can use this to avoid showing static base descriptions while still allowing flag-conditional overrides.
 
+### Session 2026-03-10 — TryAgainTests for Issue #29
+
+**Wrote 6 new tests** in `src/MyGame.Tests/TryAgainTests.cs` validating Judy's restart/retry feature.
+
+**Tests added:**
+- `Death_WithFactory_ShowsTryAgainPrompt` — factory present + death → "try again" appears in output
+- `Death_WithFactory_AnswerNo_ExitsCleanly` — "no" → IsRunning false, HasLost true
+- `Death_WithFactory_AnswerYes_RestartsGame` — "yes" → banner appears twice (two full sessions)
+- `Death_WithoutFactory_NoTryAgainPrompt` — no factory → no "try again" (backward compat)
+- `Win_DoesNotShowTryAgainPrompt` — win path + factory → prompt never shown
+- `Quit_DoesNotShowTryAgainPrompt` — voluntary quit + factory → prompt never shown
+
+**Patterns for restart/retry testing:**
+- `DeathInputs` static array shared across tests keeps death trigger DRY
+- Named parameter `stateFactory: factory` skips `world` (null) cleanly
+- Banner line count (counting "╔") detects two sessions without needing access to the restarted `GameState` object
+- `FakeInputOutput` collection expression spread `[.. DeathInputs, "no"]` composes input sequences cleanly
+- All 205 tests pass (199 baseline + 6 new)
+
+**Findings:**
+- Judy's implementation already landed and compiles; Program.cs already passes factory
+- `Run()` retry loop only prompts when `HasLost && _stateFactory != null` — clean gate
+- Quit and win both fall through to `break` without prompting — no edge cases needed beyond the 6 tests
+
+## Team Updates
+
+- **2026-03-10 — Judy completed Try-Again feature:** Factory pattern cleanly separates state creation (Program.cs) from execution (GameEngine). Backward compatible. 205 tests passing.
+
 ## Team Updates
 
 - **2026-03-09 — Johnny's architecture delivered:** IInputOutput abstraction made your test strategy possible. CommandRegistry pattern gave you clean test points. Your 114-test suite locked in the authoritative spec for the team.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -65,6 +65,74 @@ Implementation verified:
 - Not all commands updated (intentional — future PRs to follow pattern)
 - ANSI codes transparent to test assertions
 
+### Try-Again Restart Feature (Issue #29) — Judy
+
+**Date:** 2026-03-10  
+**Author:** Judy (C# Developer)
+
+## Context
+
+When the player's drone threat level exceeds the threshold, `HasLost` is set to `true` and the game loop exits. Previously the engine returned immediately, with no way to restart without re-running the process.
+
+## Decision
+
+Introduce an optional `Func<GameState>? stateFactory` parameter to `GameEngine`'s constructor. The factory is a delegate that produces a fresh `GameState` on demand. When the player dies and the factory is present, the engine prompts for a retry and — if confirmed — calls `_state = _stateFactory()` to replace the entire game state before looping into a new session.
+
+## Design Rationale
+
+- **Delegate over interface**: A `Func<GameState>` is the simplest possible contract. No new interface, no new class — just a lambda at the call site.
+- **Optional with `null` default**: Existing tests construct `GameEngine` without a factory and must not regress. `null` means "exit on death", which preserves the prior behaviour exactly.
+- **Factory owns construction**: `Program.cs` provides `() => new JsonWorldLoader().Load(worldPath).State`. The engine never needs to know how the world is loaded — it only knows how to run a session.
+- **`RunSession()` handles one full game**: Banner, intro, game loop, end message — all encapsulated. Calling it again from the retry loop gives the player an identical fresh-start experience.
+- **Prompt style**: `ColorConsole.Yellow()` used for the "Try again?" prompt, consistent with the cyberpunk colour palette (yellow = decision/choice).
+
+## Consequences
+
+- `_state` field changed from `readonly` to mutable — intentional, required for in-place replacement.
+- `Run()` now owns the outer retry loop; `RunSession()` owns a single game lifetime.
+- No change to any test setup code — all 205 tests pass (199 pre-existing + 6 new).
+
+## Files Changed
+
+- `src/MyGame/Engine/GameEngine.cs` — factory field, mutable state, `Run()` retry loop, `RunSession()` extraction
+- `src/MyGame/Program.cs` — factory lambda passed to `GameEngine` constructor
+
+### Test Coverage: Try-Again Restart (Issue #29) — River
+
+**Author:** River (Tester)  
+**Date:** 2026-03-10
+
+## Decision: 6 Tests Cover the Restart Feature
+
+### What Was Tested
+
+Six focused tests in `src/MyGame.Tests/TryAgainTests.cs`:
+
+| Test | What it guards |
+|---|---|
+| `Death_WithFactory_ShowsTryAgainPrompt` | Prompt appears on death when factory provided |
+| `Death_WithFactory_AnswerNo_ExitsCleanly` | "no" answer exits cleanly with correct state flags |
+| `Death_WithFactory_AnswerYes_RestartsGame` | "yes" answer restarts the full session (two banners in output) |
+| `Death_WithoutFactory_NoTryAgainPrompt` | No factory = no prompt (backward compatibility) |
+| `Win_DoesNotShowTryAgainPrompt` | Win path never shows prompt, even with factory |
+| `Quit_DoesNotShowTryAgainPrompt` | Voluntary quit never shows prompt, even with factory |
+
+### What Was Not Tested
+
+- **Multiple restarts in sequence** (die → yes → die → yes → no): considered low-risk; the retry loop is bounded by user input and uses the same code path on every cycle.
+- **Factory throwing an exception**: error handling in the factory is Judy's concern; no behavior is specified for this case.
+- **"YES" / "Yes" / "Y" casing variants**: the implementation uses `StartsWith("y", OrdinalIgnoreCase)` and the existing parser tests cover similar case-insensitive input patterns; not duplicated here.
+
+### Design Choices
+
+- **`DeathInputs` static array** shared across all death-triggering tests — single source of truth for the plaza death sequence.
+- **Banner line count** used to detect session restart — counts lines containing "╔" (unique to the title banner). This is output-observable without requiring access to the engine's internal `_state` after factory reset.
+- **Named parameter** `stateFactory: factory` used at call sites to skip the optional `world` parameter cleanly, matching the test idiom of omitting world for integration tests that don't need world metadata.
+
+### Status
+
+All 205 tests pass (199 pre-existing + 6 new).
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/src/MyGame.Tests/TryAgainTests.cs
+++ b/src/MyGame.Tests/TryAgainTests.cs
@@ -1,0 +1,171 @@
+using MyGame.Commands;
+using MyGame.Engine;
+using MyGame.Tests.Helpers;
+using Xunit;
+
+namespace MyGame.Tests;
+
+/// <summary>
+/// Tests for the "Try Again?" retry prompt shown after death (Issue #29).
+///
+/// Prompt appears only when:
+///   - HasLost == true at end of session
+///   - A state factory was provided to GameEngine
+///
+/// Death trigger sequence (from start in alley):
+///   "go down"  → tunnel (safe, no threat)
+///   "go north" → plaza  (high-risk: DroneThreatLevel = 1)
+///   "look"               DroneThreatLevel = 2
+///   "look"               DroneThreatLevel = 3
+///   "look"               DroneThreatLevel = 4 >= threshold → HasLost, !IsRunning
+/// </summary>
+public class TryAgainTests
+{
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    private static Func<GameState> BuildStateFactory()
+    {
+        var worldPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Content", "worlds", "neon-ledger.json");
+        return () => new JsonWorldLoader().Load(worldPath).State;
+    }
+
+    private static CommandRegistry BuildRegistry(GameState state)
+    {
+        var registry = new CommandRegistry();
+        registry.Register(new LookCommand());
+        registry.Register(new GoCommand());
+        registry.Register(new TakeCommand());
+        registry.Register(new DropCommand());
+        registry.Register(new InventoryCommand());
+        registry.Register(new UseCommand());
+        registry.Register(new HelpCommand(registry));
+        registry.Register(new QuitCommand());
+        return registry;
+    }
+
+    // Minimum inputs to reach and die in the plaza.
+    private static readonly string[] DeathInputs =
+    [
+        "go down",   // alley → tunnel (safe — no threat increment)
+        "go north",  // tunnel → plaza (high-risk: DroneThreatLevel = 1)
+        "look",      // DroneThreatLevel = 2
+        "look",      // DroneThreatLevel = 3
+        "look",      // DroneThreatLevel = 4 >= threshold → HasLost = true, IsRunning = false
+    ];
+
+    // ──────────────────────────────────────────────
+    // Try Again prompt behaviour
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Death_WithFactory_ShowsTryAgainPrompt()
+    {
+        var factory = BuildStateFactory();
+        var state = factory();
+        var registry = BuildRegistry(state);
+        var io = new FakeInputOutput([.. DeathInputs, "no"]);
+        var engine = new GameEngine(state, registry, io, stateFactory: factory);
+
+        engine.Run();
+
+        Assert.True(io.OutputContains("try again"),
+            $"Expected a 'try again' prompt after death when factory is provided.\nOutput:\n{io.AllOutput}");
+    }
+
+    [Fact]
+    public void Death_WithFactory_AnswerNo_ExitsCleanly()
+    {
+        var factory = BuildStateFactory();
+        var state = factory();
+        var registry = BuildRegistry(state);
+        var io = new FakeInputOutput([.. DeathInputs, "no"]);
+        var engine = new GameEngine(state, registry, io, stateFactory: factory);
+
+        engine.Run();
+
+        Assert.False(state.IsRunning, "IsRunning should be false after answering no.");
+        Assert.True(state.HasLost, "HasLost should remain true after answering no.");
+    }
+
+    [Fact]
+    public void Death_WithFactory_AnswerYes_RestartsGame()
+    {
+        var factory = BuildStateFactory();
+        var state = factory();
+        var registry = BuildRegistry(state);
+        // After death + yes → engine resets state and runs a fresh session; quit ends it
+        var io = new FakeInputOutput([.. DeathInputs, "yes", "quit"]);
+        var engine = new GameEngine(state, registry, io, stateFactory: factory);
+
+        engine.Run();
+
+        // The banner border is printed once per session; two sessions means it appears twice
+        var bannerLineCount = io.Lines.Count(l => l.Contains("╔", StringComparison.Ordinal));
+        Assert.True(bannerLineCount >= 2,
+            $"Expected banner header to appear at least twice (death session + restarted session).\nOutput:\n{io.AllOutput}");
+    }
+
+    [Fact]
+    public void Death_WithoutFactory_NoTryAgainPrompt()
+    {
+        var worldPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Content", "worlds", "neon-ledger.json");
+        var state = new JsonWorldLoader().Load(worldPath).State;
+        var registry = BuildRegistry(state);
+        var io = new FakeInputOutput(DeathInputs);
+        var engine = new GameEngine(state, registry, io); // no factory → backward-compatible path
+
+        engine.Run();
+
+        Assert.False(io.OutputContains("try again"),
+            $"Expected NO 'try again' prompt when no factory is provided.\nOutput:\n{io.AllOutput}");
+    }
+
+    [Fact]
+    public void Win_DoesNotShowTryAgainPrompt()
+    {
+        var factory = BuildStateFactory();
+        var state = factory();
+        var registry = BuildRegistry(state);
+        var io = new FakeInputOutput(
+            "go east",        // alley → bar
+            "go up",          // bar → rooftop
+            "take keycard",   // pick up keycard
+            "go down",        // rooftop → bar
+            "go west",        // bar → alley
+            "go down",        // alley → tunnel
+            "go south",       // tunnel → den
+            "take cred_chip", // pick up cred_chip
+            "go north",       // den → tunnel
+            "go north",       // tunnel → plaza       (DroneThreatLevel = 1)
+            "go north",       // plaza → checkpoint   (DroneThreatLevel = 2)
+            "use cred_chip",  // unlock checkpoint→north (DroneThreatLevel = 3)
+            "go north",       // checkpoint → lobby
+            "use keycard",    // unlock lobby→north
+            "go north"        // lobby → server (WIN)
+        );
+        var engine = new GameEngine(state, registry, io, stateFactory: factory);
+
+        engine.Run();
+
+        Assert.True(state.HasWon, "Player should have won on the full winning path.");
+        Assert.False(io.OutputContains("try again"),
+            $"Expected NO 'try again' prompt after winning — only shown on death.\nOutput:\n{io.AllOutput}");
+    }
+
+    [Fact]
+    public void Quit_DoesNotShowTryAgainPrompt()
+    {
+        var factory = BuildStateFactory();
+        var state = factory();
+        var registry = BuildRegistry(state);
+        var io = new FakeInputOutput("quit");
+        var engine = new GameEngine(state, registry, io, stateFactory: factory);
+
+        engine.Run();
+
+        Assert.False(io.OutputContains("try again"),
+            $"Expected NO 'try again' prompt when player voluntarily quits.\nOutput:\n{io.AllOutput}");
+    }
+}

--- a/src/MyGame/Engine/GameEngine.cs
+++ b/src/MyGame/Engine/GameEngine.cs
@@ -18,20 +18,43 @@ public class ConsoleIO : IInputOutput
 
 public class GameEngine
 {
-    private readonly GameState _state;
+    private GameState _state;
     private readonly CommandRegistry _commands;
     private readonly IInputOutput _io;
     private readonly LoadedWorld? _world;
+    private readonly Func<GameState>? _stateFactory;
 
-    public GameEngine(GameState state, CommandRegistry commands, IInputOutput io, LoadedWorld? world = null)
+    public GameEngine(GameState state, CommandRegistry commands, IInputOutput io, LoadedWorld? world = null, Func<GameState>? stateFactory = null)
     {
         _state = state;
         _commands = commands;
         _io = io;
         _world = world;
+        _stateFactory = stateFactory;
     }
 
     public void Run()
+    {
+        while (true)
+        {
+            RunSession();
+
+            if (_state.HasLost && _stateFactory is not null)
+            {
+                _io.Write(ColorConsole.Yellow("\nTry again? (yes/no) "));
+                var answer = _io.ReadLine();
+                if (answer is not null && answer.StartsWith("y", StringComparison.OrdinalIgnoreCase))
+                {
+                    _state = _stateFactory();
+                    continue;
+                }
+            }
+
+            break;
+        }
+    }
+
+    private void RunSession()
     {
         var title = _world?.Title ?? "N E O N   L E D G E R";
         var subtitle = _world?.Subtitle ?? "A Cyberpunk Text Adventure";

--- a/src/MyGame/Program.cs
+++ b/src/MyGame/Program.cs
@@ -26,5 +26,6 @@ registry.Register(new TalkCommand());
 registry.Register(new SaveCommand());
 registry.Register(new LoadCommand());
 
-var engine = new GameEngine(state, registry, new ConsoleIO(), loaded);
+var engine = new GameEngine(state, registry, new ConsoleIO(), loaded,
+    () => new JsonWorldLoader().Load(worldPath).State);
 engine.Run();


### PR DESCRIPTION
## Summary

Fixes #29 — when the player dies, the game now asks if they want to try again instead of exiting immediately.

## Changes

### src/MyGame/Engine/GameEngine.cs
- Added optional Func<GameState>? stateFactory parameter to the constructor
- Made _state non-readonly to allow restart
- Extracted RunSession() from Run() to handle a single game session
- Added retry loop in Run(): after death, prompts \Try again? (yes/no)\ in yellow — yes resets state via factory and replays from the banner; no exits cleanly

### src/MyGame/Program.cs
- Wired up the state factory: () => new JsonWorldLoader().Load(worldPath).State

### src/MyGame.Tests/TryAgainTests.cs
- 6 new tests covering all branches: death+yes (restart), death+no (exit), death without factory (backward compat), win (no prompt), quit (no prompt)

## Test Results

✅ 205/205 tests passing (199 pre-existing + 6 new)

## Acceptance Criteria

- [x] On player death, display a prompt asking if the player wants to try again
- [x] If yes, restart the game/level
- [x] If no, exit the game cleanly